### PR TITLE
Added a small tweak to capture the initial category the user chooses

### DIFF
--- a/hancrafted_haven/src/app/ui/products/filter-options.tsx
+++ b/hancrafted_haven/src/app/ui/products/filter-options.tsx
@@ -31,12 +31,13 @@ const FilterOptions: React.FC = () => {
   const searchParams = useSearchParams();
   const { replace } = useRouter();
   const groupedOptions = groupOptionsByType(options);
+  const initialCategory = searchParams.get("query");
 
   // State to track selected options per category
   const [selectedOptions, setSelectedOptions] = useState<{
     [key: string]: string | null;
   }>({
-    Category: null,
+    Category: initialCategory || null,
   });
 
   const handleFilter = useDebouncedCallback((term: string | null) => {


### PR DESCRIPTION
Previously, when you selected a category on the home page, it would take you to the product page with the correct category filter applied, but the corresponding button for that category would not be highlighted. (None of the buttons would be highlighted.) This update changes it so the corresponding button is highlighted.